### PR TITLE
feat: add logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ General:
  * `-target` - AWS service to send requests to.  Required.
  * `-port` - Port for the proxy to LISTEN on (will forward to whatever port you specify in target), default: `8080`.
  * `-service` - The AWS service type you are sending to, default: `es`.  This is required for the signing process.
+ * `-logging` - Enable debug logging of the request. Default to `false`
 
 HTTP Connection Tuning:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ General:
  * `-target` - AWS service to send requests to.  Required.
  * `-port` - Port for the proxy to LISTEN on (will forward to whatever port you specify in target), default: `8080`.
  * `-service` - The AWS service type you are sending to, default: `es`.  This is required for the signing process.
- * `-logging` - Enable debug logging of the request. Default to `false`
+ * `-enableBodyLogging` - Enable logging of the body's request. Default to `false`
 
 HTTP Connection Tuning:
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ type EnvConfig struct {
 	Target  string
 	Port    int    `default:"8080"`
 	Service string `default:"es"`
+	Logging bool
 }
 
 type AppConfig struct {
@@ -36,7 +37,7 @@ type AppConfig struct {
 }
 
 // NewSigningProxy proxies requests to AWS services which require URL signing using the provided credentials
-func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region string, appConfig AppConfig) *httputil.ReverseProxy {
+func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region string, appConfig AppConfig, logging bool) *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		// Rewrite request to desired server host
 		req.URL.Scheme = target.Scheme
@@ -87,6 +88,10 @@ func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region str
 				log.Printf("error reading request body: %v\n", err)
 			}
 			req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+			if logging {
+				debugBody := ioutil.NopCloser(bytes.NewBuffer(buf))
+				log.Printf("incoming request with BODY: %q", debugBody)
+			}
 
 			awsReq.SetBufferBody(buf)
 		}
@@ -148,6 +153,7 @@ func main() {
 	var flushInterval = flag.Duration("flush-interval", 0, "Flush interval to flush to the client while copying the response body.")
 	var idleConnTimeout = flag.Duration("idle-conn-timeout", 90*time.Second, "the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. Zero means no limit.")
 	var dialTimeout = flag.Duration("dial-timeout", 30*time.Second, "The maximum amount of time a dial will wait for a connect to complete.")
+	var logging = flag.Bool("logging", e.Logging, "Enable logging of the body")
 
 	flag.Parse()
 
@@ -185,7 +191,7 @@ func main() {
 	}
 
 	// Start the proxy server
-	proxy := NewSigningProxy(targetURL, creds, region, appC)
+	proxy := NewSigningProxy(targetURL, creds, region, appC, *logging)
 	listenString := fmt.Sprintf(":%v", *portFlag)
 	fmt.Printf("Listening on %v\n", listenString)
 	http.ListenAndServe(listenString, proxy)

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func main() {
 	var flushInterval = flag.Duration("flush-interval", 0, "Flush interval to flush to the client while copying the response body.")
 	var idleConnTimeout = flag.Duration("idle-conn-timeout", 90*time.Second, "the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. Zero means no limit.")
 	var dialTimeout = flag.Duration("dial-timeout", 30*time.Second, "The maximum amount of time a dial will wait for a connect to complete.")
-	var enableBodyLogging = flag.Bool("logging", e.EnableBodyLogging, "Enable logging of the body")
+	var enableBodyLogging = flag.Bool("enableBodyLogging", e.EnableBodyLogging, "Enable logging of the body")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type EnvConfig struct {
 	Target  string
 	Port    int    `default:"8080"`
 	Service string `default:"es"`
-	Logging bool
+	EnableBodyLogging bool
 }
 
 type AppConfig struct {
@@ -37,7 +37,7 @@ type AppConfig struct {
 }
 
 // NewSigningProxy proxies requests to AWS services which require URL signing using the provided credentials
-func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region string, appConfig AppConfig, logging bool) *httputil.ReverseProxy {
+func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region string, appConfig AppConfig, enableBodyLogging bool) *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		// Rewrite request to desired server host
 		req.URL.Scheme = target.Scheme
@@ -88,7 +88,7 @@ func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region str
 				log.Printf("error reading request body: %v\n", err)
 			}
 			req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-			if logging {
+			if enableBodyLogging {
 				debugBody := ioutil.NopCloser(bytes.NewBuffer(buf))
 				log.Printf("incoming request with BODY: %q", debugBody)
 			}
@@ -153,7 +153,7 @@ func main() {
 	var flushInterval = flag.Duration("flush-interval", 0, "Flush interval to flush to the client while copying the response body.")
 	var idleConnTimeout = flag.Duration("idle-conn-timeout", 90*time.Second, "the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. Zero means no limit.")
 	var dialTimeout = flag.Duration("dial-timeout", 30*time.Second, "The maximum amount of time a dial will wait for a connect to complete.")
-	var logging = flag.Bool("logging", e.Logging, "Enable logging of the body")
+	var enableBodyLogging = flag.Bool("logging", e.EnableBodyLogging, "Enable logging of the body")
 
 	flag.Parse()
 
@@ -191,7 +191,7 @@ func main() {
 	}
 
 	// Start the proxy server
-	proxy := NewSigningProxy(targetURL, creds, region, appC, *logging)
+	proxy := NewSigningProxy(targetURL, creds, region, appC, *enableBodyLogging)
 	listenString := fmt.Sprintf(":%v", *portFlag)
 	fmt.Printf("Listening on %v\n", listenString)
 	http.ListenAndServe(listenString, proxy)


### PR DESCRIPTION
[MT-199](https://spoudlab.atlassian.net/browse/MT-199)

This PR enable logging when the flag -logging is set to true.
This feature will logs the body of the request, i.e.:
2020/05/18 16:20:50 incoming request with BODY: {"dd"}

P.S.: sorry to the double notification, I forked the repo to know where it comes from
I've created a PR on their side, we could discuss if it make sense or not to delete it